### PR TITLE
Xslt for software

### DIFF
--- a/test/data/software/reference.xml
+++ b/test/data/software/reference.xml
@@ -2,6 +2,9 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
    <identifier identifierType="swMATH">2</identifier>
+    <alternateIdentifiers>
+      <alternateIdentifier alternateIdentifierType="URL">https://zbmath.org/software/2</alternateIdentifier>
+   </alternateIdentifiers>
           <creators>
       <creator>
          <creatorName nameType="Personal">Li, X.S.</creatorName>

--- a/test/data/software/reference.xml
+++ b/test/data/software/reference.xml
@@ -43,4 +43,5 @@
       <subject subjectScheme="msc2020">92</subject>
       <subject subjectScheme="keyword">orms</subject>
    </subjects>
+    <resourceType resourceTypeGeneral="Software"/>
 </resource>

--- a/test/test_metadata_software_Datacite.py
+++ b/test/test_metadata_software_Datacite.py
@@ -1,5 +1,4 @@
 import os
-import re
 import unittest
 
 import lxml.etree as ET
@@ -17,7 +16,7 @@ if os.path.basename(os.getcwd()) == 'test':
 
             transform = ET.XSLT(xslt)  # is it a reserved word
             newdom = transform(dom)
-
+            print(newdom) #this print is to see the result of the trnasformation when by running the test
             real_string = ET.tostring(newdom, pretty_print=True, encoding='utf8').decode()
             # test if result is parsable
             reference = ET.parse('test/data/software/reference.xml')

--- a/xslt/software/xslt-software-datacite.xslt
+++ b/xslt/software/xslt-software-datacite.xslt
@@ -9,6 +9,10 @@
          <resource xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
             <!-- Roots of the metadata -->
             <xsl:apply-templates select="root/id"/>
+
+             <alternateIdentifiers>
+            <xsl:apply-templates select="root/zbmath_url"/>
+            </alternateIdentifiers>
             <creators>
                 <xsl:apply-templates select="root/authors"/>
             </creators>
@@ -31,7 +35,11 @@
 <xsl:value-of select="."/>
  </identifier>
 </xsl:template>
-
+        <xsl:template match="zbmath_url">
+        <alternateIdentifier alternateIdentifierType="URL">
+            <xsl:value-of select="."/>
+        </alternateIdentifier>
+        </xsl:template>
  <xsl:template match="authors">
         <creator>
             <creatorName nameType="Personal">

--- a/xslt/software/xslt-software-datacite.xslt
+++ b/xslt/software/xslt-software-datacite.xslt
@@ -27,7 +27,7 @@
                 <xsl:apply-templates select="root/classification"/>
                 <xsl:apply-templates select="root/keywords"/>
             </subjects>
-
+ <resourceType resourceTypeGeneral="Software"/>
 </resource>
 </xsl:template>
 <xsl:template match="id">

--- a/xslt/software/xslt-software-datacite.xslt
+++ b/xslt/software/xslt-software-datacite.xslt
@@ -21,6 +21,8 @@
                  </titles>
                 <descriptions>
                 <xsl:apply-templates select="root/description"/>
+                    <xsl:apply-templates select="root/operating_systems"/>
+                    <xsl:apply-templates select="root/programming_languages"/>
                 </descriptions>
       <xsl:apply-templates select="root/standard_articles/year"/>
             <subjects>
@@ -64,6 +66,23 @@
          <xsl:value-of select="."/>
         </description>
         </xsl:template>
+      <xsl:template match="operating_systems">
+    <xsl:if test=". != ''">
+        <description xml:lang="en" descriptionType="TechnicalInfo">
+            <xsl:text>operating systems: </xsl:text>
+            <xsl:value-of select="."/>
+        </description>
+    </xsl:if>
+</xsl:template>
+
+<xsl:template match="programming_languages">
+    <xsl:if test=". != ''">
+        <description xml:lang="en" descriptionType="TechnicalInfo">
+        <xsl:text>programming languages : </xsl:text>
+            <xsl:value-of select="."/>
+        </description>
+    </xsl:if>
+</xsl:template>
   <xsl:template match="year">
             <!-- Transformation of publicationYear -->
         <publicationYear>


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- writing a unittest code similar to the unittest of articles with few differences  to test the transformation of software metadata
- creating the alternateIdentifiers node and adding the url of zbmath in it 
-  adding the operating_systems and programming_languages  templates to the xslt
to be generated 




in our  plain.xml they are empty nodes  and can not generate any value 
but in our metadata from the rest API there are softwares that have those values 
 
therefore they have not been added to the reference.xml 
however i made a sample to for testing 
I added additional Text to the result because Datacite schema says it is TechnicalInfo so i thought maybe adding more information could be much better. 
and this is the result . i can delete the textual information from the xslt if you see that it is not needed. 

 <description xml:lang="en" descriptionType="TechnicalInfo">operating systems: Linux , MacOs</description>
      <description xml:lang="en" descriptionType="TechnicalInfo">programming languages : python</description>

looking forward for your feedback 


