### PR TITLE
removing the given and family name from the templates authors

### DIFF
--- a/test/data/software/Test_Result_Codemeta.xml
+++ b/test/data/software/Test_Result_Codemeta.xml
@@ -14,13 +14,9 @@
    </swhdeposit:deposit>
     <codemeta:author>
       <codemeta:name>Kursa, Miron Bartosz</codemeta:name>
-      <codemeta:givenName>Miron Bartosz</codemeta:givenName>
-      <codemeta:familyName>Kursa</codemeta:familyName>
    </codemeta:author>
    <codemeta:author>
       <codemeta:name>Rudnicki, Witold Remigiusz</codemeta:name>
-      <codemeta:givenName>Witold Remigiusz</codemeta:givenName>
-      <codemeta:familyName>Rudnicki</codemeta:familyName>
    </codemeta:author>
    <codemeta:name>Boruta</codemeta:name>
    <codemeta:description>zbMATH Open Web Interface contents unavailable due to conflicting licenses.</codemeta:description>

--- a/xslt/software/xslt-software-Codemeta.xslt
+++ b/xslt/software/xslt-software-Codemeta.xslt
@@ -104,12 +104,6 @@
         <codemeta:name>
             <xsl:value-of select="."/>
         </codemeta:name>
-        <codemeta:givenName>
-            <xsl:value-of select="normalize-space(substring-after(., ','))"/>
-        </codemeta:givenName>
-        <codemeta:familyName>
-            <xsl:value-of select="substring-before(., ',')"/>
-        </codemeta:familyName>
         </codemeta:author>
     </xsl:template>
 


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- removing the given name and family name from the xslt 
so it could generate only the codemeta:name element as requested. 
- 
-  

