### PR TITLE
extract the year from source

### DIFF
--- a/src/zbmath_rest2oai/getAsXml.py
+++ b/src/zbmath_rest2oai/getAsXml.py
@@ -72,12 +72,24 @@ def extract_tags(result):
         tags.append('JFM')
     return tags
 
+def extract_year_from_source(source):
 
+    if isinstance(source, dict):
+        if "series" in source and isinstance(source["series"], list):
+            for series in source["series"]:
+                if "year" in series:
+                    return series["year"]
+        elif "book" in source and isinstance(source["book"], list):
+            for book in source["book"]:
+                if "year" in book:
+                    return book["year"]
+    return None
 
 def add_references_to_software(api_uri, dict_res):
     list_articles_ids_to_soft = []
     list_articles_ids_and_alter_ids_to_soft = []
     list_references_year_alt = []
+    source_year = None
     if "software" in api_uri:
         if api_uri.startswith("https://api.zbmath.org/v1/software/_all?start_after=")==False:
             soft_id=api_uri.split("/")[-1]
@@ -106,6 +118,9 @@ def add_references_to_software(api_uri, dict_res):
                         year = entry["datestamp"][:4]
                         list_references_year_alt.append(year)
 
+                if "source" in entry:
+                    source_year = extract_year_from_source(entry["source"])
+
                 list_articles_ids_to_soft.extend(list_ids)
                 list_articles_ids_and_alter_ids_to_soft.extend(list_ids_and_alter)
 
@@ -113,9 +128,10 @@ def add_references_to_software(api_uri, dict_res):
 
         if isinstance(dict_res, dict):
             dict_res["references"] = list_articles_ids_to_soft
-            # Wrap it in a list to make it iterable for your existing loop
             dict_res["references_alt"] = list_articles_ids_and_alter_ids_to_soft
             dict_res["references_year_alt"] = list_references_year_alt
+            if source_year is not None:  # Add source_year only if it was found
+                dict_res["source_year"] = source_year
             dict_res = [dict_res]
 
     return dict_res

--- a/test/data/software/plain_with_references.xml
+++ b/test/data/software/plain_with_references.xml
@@ -442,6 +442,7 @@
     <name>deal.ii</name>
   </related_software>
   <source_code/>
+  <source_year>2005</source_year>
   <standard_articles>
     <authors/>
     <id>2187846</id>


### PR DESCRIPTION


**Changes**:
- writing a new function in getAsXml to extract the year of source from the articles of the softwares 
- adding the source_year node in plain_with_references for testing and also to show the result of the extraction


