### PR TITLE
removing the unwanted name spaces and correcting the software number

### DIFF
--- a/src/swmath2swh/staging_deposit_v2.py
+++ b/src/swmath2swh/staging_deposit_v2.py
@@ -1,9 +1,7 @@
-from swmath2swh.restApi_software_Json import process_metadata
-from swmath2swh.convertSoftware_from_json_toXml import convert_json_to_xml
+
 import defusedxml.ElementTree as DET  # Using defusedxml for safe XML parsing
 from defusedxml.lxml import fromstring
 import lxml.etree as ET
-import pandas as pd
 import subprocess
 import time
 import tempfile
@@ -15,7 +13,7 @@ env = os.environ.copy()
 env['SWMATH_USER_DEPOSIT'] = os.getenv('SWMATH_USER_DEPOSIT')
 env['SWMATH_PWD_DEPOSIT'] = os.getenv('SWMATH_PWD_DEPOSIT')
 
-xsl_filename = '../xslt/software/xslt_SWH_deposit.xslt'
+xsl_filename = '../../xslt/software/xslt_SWH_deposit.xslt'
 
 # Fetch XML data
 r = requests.get("https://oai.portal.mardi4nfdi.de/oai/OAIHandler?verb=GetRecord&metadataPrefix=codemeta&identifier=oai:swmath.org:4532")
@@ -34,8 +32,11 @@ xslt = ET.parse(xsl_filename)
 transform = ET.XSLT(xslt)
 newdom = transform(lxml_dom)
 formatted_newdom = ET.tostring(newdom, pretty_print=True, encoding='unicode')
+formatted_newdom = re.sub(r'xmlns:xsi="[^"]+"', '', formatted_newdom)
 formatted_newdom = re.sub(r'xmlns:ns\d+="[^"]+"', '', formatted_newdom)
 formatted_newdom = re.sub(r'ns\d+:', 'codemeta:', formatted_newdom)
+formatted_newdom = re.sub(r'<\s*([^>]+?)\s*>', r'<\1>', formatted_newdom)
+formatted_newdom = re.sub(r'<\s*/\s*([^>]+?)\s*>', r'</\1>', formatted_newdom)
 print(formatted_newdom)
 
 # Write transformed XML to a temporary file


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- removing unsued packages and libraries from the code  of staging_deposit_v2.py 
- adding 3 lines of re.sub to ensure that the transformation's result is clean and compact.  based on swh-team demand. 
-correcting the number of the software it should be 5432 and it was 5432 only one digit is changed. 





this is the past result 



```xml
 <codemeta:citation    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
      <codemeta:id>https://api.zbmath.org/v1/document/7595014</codemeta:id>
   </codemeta:citation>

```


and this is the current result after the adjustments 

```xml
 <codemeta:citation>
      <codemeta:id>https://api.zbmath.org/v1/document/7595014</codemeta:id>
   </codemeta:citation>
```






here you can find again the link to the issue on gitlab , based on valentin's advice i made these adjustments


https://gitlab.softwareheritage.org/outreach/partnerships/swmath/-/issues/3#note_191667










