### PR TITLE
update id and url for software codemeta

### DIFF
--- a/test/data/software/Datacite-software-reference.xml
+++ b/test/data/software/Datacite-software-reference.xml
@@ -23,7 +23,23 @@
     </descriptions>
     <publicationYear>2003</publicationYear>
     <subjects>
-        <subject subjectScheme="keyword">orms</subject>
+      <subject subjectScheme="msc2020">35</subject>
+      <subject subjectScheme="msc2020">65</subject>
+      <subject subjectScheme="msc2020">68</subject>
+      <subject subjectScheme="msc2020">74</subject>
+      <subject subjectScheme="msc2020">76</subject>
+      <subject subjectScheme="msc2020">05</subject>
+      <subject subjectScheme="msc2020">15</subject>
+      <subject subjectScheme="msc2020">60</subject>
+      <subject subjectScheme="msc2020">78</subject>
+      <subject subjectScheme="msc2020">80</subject>
+      <subject subjectScheme="msc2020">81</subject>
+      <subject subjectScheme="msc2020">82</subject>
+      <subject subjectScheme="msc2020">85</subject>
+      <subject subjectScheme="msc2020">86</subject>
+      <subject subjectScheme="msc2020">90</subject>
+      <subject subjectScheme="msc2020">92</subject>
+      <subject subjectScheme="keyword">orms</subject>
     </subjects>
     <language>English</language>
     <resourceType resourceTypeGeneral="Software">:none</resourceType>
@@ -54,8 +70,8 @@
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5167018</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5128211</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5251239</relatedIdentifier>
-      <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/6766231</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5706020</relatedIdentifier>
+      <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/6766231</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5244390</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5762200</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7099306</relatedIdentifier>
@@ -63,8 +79,8 @@
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/6669500</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5187739</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5670978</relatedIdentifier>
-      <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5969946</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7687320</relatedIdentifier>
+      <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5969946</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7914911</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/6220134</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7099336</relatedIdentifier>
@@ -79,10 +95,10 @@
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5784806</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5510606</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5982908</relatedIdentifier>
-      <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7138575</relatedIdentifier>
-      <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/6669495</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/6449261</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7055073</relatedIdentifier>
+      <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/6669495</relatedIdentifier>
+      <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7138575</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/6910452</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/6265830</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/6908831</relatedIdentifier>
@@ -92,11 +108,11 @@
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/6443071</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/6128531</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7271902</relatedIdentifier>
-      <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5221096</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7308040</relatedIdentifier>
+      <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5221096</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/6054722</relatedIdentifier>
-      <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7301661</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7506624</relatedIdentifier>
+      <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7301661</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5827163</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5244394</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/6897553</relatedIdentifier>
@@ -106,16 +122,16 @@
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7644848</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5862151</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/6911772</relatedIdentifier>
-      <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5947775</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5762238</relatedIdentifier>
+      <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5947775</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5187737</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7908567</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7631087</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5801879</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5798197</relatedIdentifier>
-      <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7981588</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/5693879</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7315215</relatedIdentifier>
+      <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7981588</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7539438</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7495530</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="URL" relationType="IsCitedBy">https://api.zbmath.org/v1/document/7516896</relatedIdentifier>
@@ -170,16 +186,16 @@
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1017/S0962492904000200</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1016/j.compfluid.2005.07.005</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1137/070707002</relatedIdentifier>
-      <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1137/16M1079221</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1007/s10287-008-0080-5</relatedIdentifier>
+      <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1137/16M1079221</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1137/050637315</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1016/j.jcp.2010.03.028</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1137/18M1181353</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1017/S0962492919000035</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1002/nme.4729</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1007/s00200-007-0037-x</relatedIdentifier>
-      <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1017/S0022112010005380</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1007/978-3-031-25820-6</relatedIdentifier>
+      <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1017/S0022112010005380</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1007/s10444-024-10176-x</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="arXiv" relationType="IsCitedBy">2211.07572</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1007/s00158-007-0105-7</relatedIdentifier>
@@ -200,11 +216,11 @@
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1016/j.jcp.2010.04.049</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1002/gamm.201490037</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1016/j.cma.2009.07.012</relatedIdentifier>
-      <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1007/s13160-019-00381-3</relatedIdentifier>
-      <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1002/nme.4711</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1137/140980375</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="arXiv" relationType="IsCitedBy">1501.06852</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1016/j.cma.2015.07.009</relatedIdentifier>
+      <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1002/nme.4711</relatedIdentifier>
+      <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1007/s13160-019-00381-3</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1016/j.cam.2017.11.035</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="arXiv" relationType="IsCitedBy">1712.08872</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1016/j.jnnfm.2011.06.006</relatedIdentifier>
@@ -218,12 +234,12 @@
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1007/s00466-011-0661-y</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1137/18M1189348</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="arXiv" relationType="IsCitedBy">1801.09809</relatedIdentifier>
-      <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1201/9781584888093</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1016/j.camwa.2021.01.003</relatedIdentifier>
+      <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1201/9781584888093</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1016/j.compfluid.2008.10.002</relatedIdentifier>
-      <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1016/j.jcp.2019.04.023</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1016/j.jcp.2020.109706</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="arXiv" relationType="IsCitedBy">1909.01467</relatedIdentifier>
+      <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1016/j.jcp.2019.04.023</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1007/978-3-642-13872-0_15</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1137/050622547</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1016/j.compfluid.2018.02.028</relatedIdentifier>
@@ -234,18 +250,18 @@
       <relatedIdentifier relatedIdentifierType="arXiv" relationType="IsCitedBy">2012.07648</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1007/978-3-642-19328-6_38</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1007/s10596-012-9330-2</relatedIdentifier>
-      <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1260/174830108786231704</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1016/j.jcp.2010.04.022</relatedIdentifier>
+      <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1260/174830108786231704</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1007/s00200-007-0035-z</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1145/3582492</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="arXiv" relationType="IsCitedBy">2107.10561</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1007/978-3-319-17353-5_12</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1137/080714877</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1016/j.cam.2010.07.002</relatedIdentifier>
-      <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1002/nme.7597</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1080/10618560802238267</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1007/978-3-030-47174-3_2</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="arXiv" relationType="IsCitedBy">1905.00606</relatedIdentifier>
+      <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1002/nme.7597</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1007/s10444-022-09931-9</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="arXiv" relationType="IsCitedBy">2102.05367</relatedIdentifier>
       <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1137/21M1411603</relatedIdentifier>

--- a/test/data/software/OpenAire-software-reference.xml
+++ b/test/data/software/OpenAire-software-reference.xml
@@ -23,6 +23,22 @@
       <datacite:title>SuperLU-DIST</datacite:title>
    </datacite:titles>
    <datacite:subjects>
+      <datacite:subject subjectScheme="msc2020">35</datacite:subject>
+      <datacite:subject subjectScheme="msc2020">65</datacite:subject>
+      <datacite:subject subjectScheme="msc2020">68</datacite:subject>
+      <datacite:subject subjectScheme="msc2020">74</datacite:subject>
+      <datacite:subject subjectScheme="msc2020">76</datacite:subject>
+      <datacite:subject subjectScheme="msc2020">05</datacite:subject>
+      <datacite:subject subjectScheme="msc2020">15</datacite:subject>
+      <datacite:subject subjectScheme="msc2020">60</datacite:subject>
+      <datacite:subject subjectScheme="msc2020">78</datacite:subject>
+      <datacite:subject subjectScheme="msc2020">80</datacite:subject>
+      <datacite:subject subjectScheme="msc2020">81</datacite:subject>
+      <datacite:subject subjectScheme="msc2020">82</datacite:subject>
+      <datacite:subject subjectScheme="msc2020">85</datacite:subject>
+      <datacite:subject subjectScheme="msc2020">86</datacite:subject>
+      <datacite:subject subjectScheme="msc2020">90</datacite:subject>
+      <datacite:subject subjectScheme="msc2020">92</datacite:subject>
       <datacite:subject subjectScheme="keyword">orms</datacite:subject>
    </datacite:subjects>
    <datacite:relatedIdentifiers>
@@ -48,8 +64,8 @@
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5167018</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5128211</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5251239</datacite:relatedIdentifier>
-      <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/6766231</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5706020</datacite:relatedIdentifier>
+      <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/6766231</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5244390</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5762200</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7099306</datacite:relatedIdentifier>
@@ -57,8 +73,8 @@
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/6669500</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5187739</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5670978</datacite:relatedIdentifier>
-      <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5969946</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7687320</datacite:relatedIdentifier>
+      <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5969946</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7914911</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/6220134</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7099336</datacite:relatedIdentifier>
@@ -73,10 +89,10 @@
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5784806</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5510606</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5982908</datacite:relatedIdentifier>
-      <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7138575</datacite:relatedIdentifier>
-      <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/6669495</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/6449261</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7055073</datacite:relatedIdentifier>
+      <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/6669495</datacite:relatedIdentifier>
+      <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7138575</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/6910452</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/6265830</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/6908831</datacite:relatedIdentifier>
@@ -86,11 +102,11 @@
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/6443071</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/6128531</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7271902</datacite:relatedIdentifier>
-      <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5221096</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7308040</datacite:relatedIdentifier>
+      <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5221096</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/6054722</datacite:relatedIdentifier>
-      <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7301661</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7506624</datacite:relatedIdentifier>
+      <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7301661</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5827163</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5244394</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/6897553</datacite:relatedIdentifier>
@@ -100,16 +116,16 @@
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7644848</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5862151</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/6911772</datacite:relatedIdentifier>
-      <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5947775</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5762238</datacite:relatedIdentifier>
+      <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5947775</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5187737</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7908567</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7631087</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5801879</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5798197</datacite:relatedIdentifier>
-      <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7981588</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/5693879</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7315215</datacite:relatedIdentifier>
+      <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7981588</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7539438</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7495530</datacite:relatedIdentifier>
       <datacite:relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementedBy">https://api.zbmath.org/v1/document/7516896</datacite:relatedIdentifier>

--- a/test/data/software/plain_with_references.xml
+++ b/test/data/software/plain_with_references.xml
@@ -1,8 +1,23 @@
 <root>
-  <articles_count>118</articles_count>
+  <articles_count>119</articles_count>
   <authors>Li, X. S.</authors>
   <authors>Demmel, J. W.</authors>
-  <classification/>
+  <classification>35</classification>
+  <classification>65</classification>
+  <classification>68</classification>
+  <classification>74</classification>
+  <classification>76</classification>
+  <classification>05</classification>
+  <classification>15</classification>
+  <classification>60</classification>
+  <classification>78</classification>
+  <classification>80</classification>
+  <classification>81</classification>
+  <classification>82</classification>
+  <classification>85</classification>
+  <classification>86</classification>
+  <classification>90</classification>
+  <classification>92</classification>
   <dependencies/>
   <description>zbMATH Open Web Interface contents unavailable due to conflicting licenses.</description>
   <homepage>http://crd-legacy.lbl.gov/~xiaoye/SuperLU/</homepage>
@@ -34,8 +49,8 @@
   <references>5167018</references>
   <references>5128211</references>
   <references>5251239</references>
-  <references>6766231</references>
   <references>5706020</references>
+  <references>6766231</references>
   <references>5244390</references>
   <references>5762200</references>
   <references>7099306</references>
@@ -43,8 +58,8 @@
   <references>6669500</references>
   <references>5187739</references>
   <references>5670978</references>
-  <references>5969946</references>
   <references>7687320</references>
+  <references>5969946</references>
   <references>7914911</references>
   <references>6220134</references>
   <references>7099336</references>
@@ -59,10 +74,10 @@
   <references>5784806</references>
   <references>5510606</references>
   <references>5982908</references>
-  <references>7138575</references>
-  <references>6669495</references>
   <references>6449261</references>
   <references>7055073</references>
+  <references>6669495</references>
+  <references>7138575</references>
   <references>6910452</references>
   <references>6265830</references>
   <references>6908831</references>
@@ -72,11 +87,11 @@
   <references>6443071</references>
   <references>6128531</references>
   <references>7271902</references>
-  <references>5221096</references>
   <references>7308040</references>
+  <references>5221096</references>
   <references>6054722</references>
-  <references>7301661</references>
   <references>7506624</references>
+  <references>7301661</references>
   <references>5827163</references>
   <references>5244394</references>
   <references>6897553</references>
@@ -86,16 +101,16 @@
   <references>7644848</references>
   <references>5862151</references>
   <references>6911772</references>
-  <references>5947775</references>
   <references>5762238</references>
+  <references>5947775</references>
   <references>5187737</references>
   <references>7908567</references>
   <references>7631087</references>
   <references>5801879</references>
   <references>5798197</references>
-  <references>7981588</references>
   <references>5693879</references>
   <references>7315215</references>
+  <references>7981588</references>
   <references>7539438</references>
   <references>7495530</references>
   <references>7516896</references>
@@ -150,8 +165,8 @@
   <references_alt>5167018;10.1017/S0962492904000200</references_alt>
   <references_alt>5128211;10.1016/j.compfluid.2005.07.005</references_alt>
   <references_alt>5251239;10.1137/070707002</references_alt>
-  <references_alt>6766231;10.1137/16M1079221</references_alt>
   <references_alt>5706020;10.1007/s10287-008-0080-5</references_alt>
+  <references_alt>6766231;10.1137/16M1079221</references_alt>
   <references_alt>5244390;10.1137/050637315</references_alt>
   <references_alt>5762200;10.1016/j.jcp.2010.03.028</references_alt>
   <references_alt>7099306;10.1137/18M1181353</references_alt>
@@ -159,8 +174,8 @@
   <references_alt>6669500;10.1002/nme.4729</references_alt>
   <references_alt>5187739;10.1007/s00200-007-0037-x</references_alt>
   <references_alt>5670978</references_alt>
-  <references_alt>5969946;10.1017/S0022112010005380</references_alt>
   <references_alt>7687320;10.1007/978-3-031-25820-6</references_alt>
+  <references_alt>5969946;10.1017/S0022112010005380</references_alt>
   <references_alt>7914911;10.1007/s10444-024-10176-x;2211.07572</references_alt>
   <references_alt>6220134;10.1007/s00158-007-0105-7</references_alt>
   <references_alt>7099336;10.1137/17M1153674;1710.08779</references_alt>
@@ -175,10 +190,10 @@
   <references_alt>5784806;10.1016/j.jcp.2010.04.049</references_alt>
   <references_alt>5510606;10.1002/gamm.201490037</references_alt>
   <references_alt>5982908;10.1016/j.cma.2009.07.012</references_alt>
-  <references_alt>7138575;10.1007/s13160-019-00381-3</references_alt>
-  <references_alt>6669495;10.1002/nme.4711</references_alt>
   <references_alt>6449261;10.1137/140980375;1501.06852</references_alt>
   <references_alt>7055073;10.1016/j.cma.2015.07.009</references_alt>
+  <references_alt>6669495;10.1002/nme.4711</references_alt>
+  <references_alt>7138575;10.1007/s13160-019-00381-3</references_alt>
   <references_alt>6910452;10.1016/j.cam.2017.11.035;1712.08872</references_alt>
   <references_alt>6265830;10.1016/j.jnnfm.2011.06.006</references_alt>
   <references_alt>6908831;10.1145/2786977;1404.0447</references_alt>
@@ -188,11 +203,11 @@
   <references_alt>6443071;10.1007/978-3-319-17073-2</references_alt>
   <references_alt>6128531;10.1007/s00466-011-0661-y</references_alt>
   <references_alt>7271902;10.1137/18M1189348;1801.09809</references_alt>
-  <references_alt>5221096;10.1201/9781584888093</references_alt>
   <references_alt>7308040;10.1016/j.camwa.2021.01.003</references_alt>
+  <references_alt>5221096;10.1201/9781584888093</references_alt>
   <references_alt>6054722;10.1016/j.compfluid.2008.10.002</references_alt>
-  <references_alt>7301661;10.1016/j.jcp.2019.04.023</references_alt>
   <references_alt>7506624;10.1016/j.jcp.2020.109706;1909.01467</references_alt>
+  <references_alt>7301661;10.1016/j.jcp.2019.04.023</references_alt>
   <references_alt>5827163;10.1007/978-3-642-13872-0_15</references_alt>
   <references_alt>5244394;10.1137/050622547</references_alt>
   <references_alt>6897553;10.1016/j.compfluid.2018.02.028</references_alt>
@@ -202,16 +217,16 @@
   <references_alt>7644848;10.1016/j.cma.2022.115775;2012.07648</references_alt>
   <references_alt>5862151;10.1007/978-3-642-19328-6_38</references_alt>
   <references_alt>6911772;10.1007/s10596-012-9330-2</references_alt>
-  <references_alt>5947775;10.1260/174830108786231704</references_alt>
   <references_alt>5762238;10.1016/j.jcp.2010.04.022</references_alt>
+  <references_alt>5947775;10.1260/174830108786231704</references_alt>
   <references_alt>5187737;10.1007/s00200-007-0035-z</references_alt>
   <references_alt>7908567;10.1145/3582492;2107.10561</references_alt>
   <references_alt>7631087;10.1007/978-3-319-17353-5_12</references_alt>
   <references_alt>5801879;10.1137/080714877</references_alt>
   <references_alt>5798197;10.1016/j.cam.2010.07.002</references_alt>
-  <references_alt>7981588;10.1002/nme.7597</references_alt>
   <references_alt>5693879;10.1080/10618560802238267</references_alt>
   <references_alt>7315215;10.1007/978-3-030-47174-3_2;1905.00606</references_alt>
+  <references_alt>7981588;10.1002/nme.7597</references_alt>
   <references_alt>7539438;10.1007/s10444-022-09931-9;2102.05367</references_alt>
   <references_alt>7495530;10.1137/21M1411603</references_alt>
   <references_alt>7516896;10.1080/10618562.2016.1205737</references_alt>
@@ -266,8 +281,8 @@
   <references_year_alt>2007</references_year_alt>
   <references_year_alt>2007</references_year_alt>
   <references_year_alt>2008</references_year_alt>
-  <references_year_alt>2017</references_year_alt>
   <references_year_alt>2010</references_year_alt>
+  <references_year_alt>2017</references_year_alt>
   <references_year_alt>2008</references_year_alt>
   <references_year_alt>2010</references_year_alt>
   <references_year_alt>2019</references_year_alt>
@@ -275,8 +290,8 @@
   <references_year_alt>2016</references_year_alt>
   <references_year_alt>2007</references_year_alt>
   <references_year_alt>2010</references_year_alt>
-  <references_year_alt>2011</references_year_alt>
   <references_year_alt>2023</references_year_alt>
+  <references_year_alt>2011</references_year_alt>
   <references_year_alt>2024</references_year_alt>
   <references_year_alt>2013</references_year_alt>
   <references_year_alt>2019</references_year_alt>
@@ -291,9 +306,9 @@
   <references_year_alt>2010</references_year_alt>
   <references_year_alt>2009</references_year_alt>
   <references_year_alt>2011</references_year_alt>
+  <references_year_alt>2015</references_year_alt>
   <references_year_alt>2019</references_year_alt>
   <references_year_alt>2016</references_year_alt>
-  <references_year_alt>2015</references_year_alt>
   <references_year_alt>2019</references_year_alt>
   <references_year_alt>2018</references_year_alt>
   <references_year_alt>2014</references_year_alt>
@@ -304,11 +319,11 @@
   <references_year_alt>2015</references_year_alt>
   <references_year_alt>2013</references_year_alt>
   <references_year_alt>2020</references_year_alt>
+  <references_year_alt>2021</references_year_alt>
   <references_year_alt>2007</references_year_alt>
-  <references_year_alt>2021</references_year_alt>
   <references_year_alt>2012</references_year_alt>
-  <references_year_alt>2021</references_year_alt>
   <references_year_alt>2022</references_year_alt>
+  <references_year_alt>2021</references_year_alt>
   <references_year_alt>2010</references_year_alt>
   <references_year_alt>2008</references_year_alt>
   <references_year_alt>2018</references_year_alt>
@@ -318,16 +333,16 @@
   <references_year_alt>2023</references_year_alt>
   <references_year_alt>2011</references_year_alt>
   <references_year_alt>2018</references_year_alt>
-  <references_year_alt>2011</references_year_alt>
   <references_year_alt>2010</references_year_alt>
+  <references_year_alt>2011</references_year_alt>
   <references_year_alt>2007</references_year_alt>
   <references_year_alt>2024</references_year_alt>
   <references_year_alt>2022</references_year_alt>
   <references_year_alt>2010</references_year_alt>
   <references_year_alt>2010</references_year_alt>
-  <references_year_alt>2025</references_year_alt>
   <references_year_alt>2010</references_year_alt>
   <references_year_alt>2021</references_year_alt>
+  <references_year_alt>2025</references_year_alt>
   <references_year_alt>2022</references_year_alt>
   <references_year_alt>2022</references_year_alt>
   <references_year_alt>2022</references_year_alt>
@@ -378,12 +393,12 @@
     <name>SuperLU</name>
   </related_software>
   <related_software>
-    <id>503</id>
-    <name>LAPACK</name>
-  </related_software>
-  <related_software>
     <id>679</id>
     <name>PARDISO</name>
+  </related_software>
+  <related_software>
+    <id>503</id>
+    <name>LAPACK</name>
   </related_software>
   <related_software>
     <id>426</id>
@@ -406,6 +421,10 @@
     <name>ScaLAPACK</name>
   </related_software>
   <related_software>
+    <id>23170</id>
+    <name>GitHub</name>
+  </related_software>
+  <related_software>
     <id>4827</id>
     <name>mctoolbox</name>
   </related_software>
@@ -414,8 +433,8 @@
     <name>WSMP</name>
   </related_software>
   <related_software>
-    <id>23170</id>
-    <name>GitHub</name>
+    <id>20382</id>
+    <name>CSparse</name>
   </related_software>
   <related_software>
     <id>4218</id>
@@ -436,10 +455,6 @@
   <related_software>
     <id>3216</id>
     <name>BLAS</name>
-  </related_software>
-  <related_software>
-    <id>3516</id>
-    <name>deal.ii</name>
   </related_software>
   <source_code/>
   <source_year>2005</source_year>

--- a/test/test_extract_tags.py
+++ b/test/test_extract_tags.py
@@ -21,28 +21,7 @@ class PlainXmlTest(unittest.TestCase):
             'https://api.zbmath.org/v1/software/12',
             headers=headers)
         real_tags = extract_tags(r.json()['result'])
-        assert real_tags ==  ['(optics),',
- '2010:',
- '60J70',
- '65C50',
- '78A05',
- '78A45',
- '82D25',
- 'Appl.',
- 'Crystals',
- 'Diffraction,',
- 'Geometric',
- 'MSC',
- 'Other',
- 'computational',
- 'diffusion',
- 'in',
- 'of',
- 'optics,',
- 'probability,',
- 'problems',
- 'scattering',
- 'theory,']
+        assert real_tags == ['60', '65', '78', '82']
 
 
 

--- a/xslt/software/xslt-software-Codemeta.xslt
+++ b/xslt/software/xslt-software-Codemeta.xslt
@@ -51,12 +51,21 @@
         </entry>
     </xsl:template>
 
-    <xsl:template match="id"  mode="id">
-        <id>
-            <xsl:text>https://swmath.org/software/</xsl:text>
-            <xsl:value-of select="."/>
-        </id>
-    </xsl:template>
+  <xsl:template match="id" mode="id">
+  <id>
+    <xsl:text>https://swmath.org/software/</xsl:text>
+    <xsl:choose>
+      <xsl:when test="starts-with(., 'oai:swmath.org:')">
+        <xsl:value-of select="substring-after(., 'oai:swmath.org:')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="."/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </id>
+</xsl:template>
+
+
 
     <xsl:template match="swhdeposit:deposit">
         <swhdeposit:deposit>
@@ -217,13 +226,22 @@
        </xsl:if>
     </xsl:template>
 
-    <xsl:template match="id">
-  <xsl:if test="normalize-space(.) != '' and . != 'None'">
+   <xsl:template match="id">
+    <xsl:if test="normalize-space(.) != '' and . != 'None'">
         <codemeta:url>
-            <xsl:text>https://api.zbmath.org/v1/software/</xsl:text>
-            <xsl:value-of select="."/>
+      <xsl:text>https://api.zbmath.org/v1/software/</xsl:text>
+      <xsl:choose>
+        <xsl:when test="starts-with(., 'oai:swmath.org:')">
+          <xsl:value-of select="substring-after(., 'oai:swmath.org:')"/>
+        </xsl:when>
+          <xsl:otherwise>
+          <xsl:value-of select="."/>
+          </xsl:otherwise>
+        </xsl:choose>
         </codemeta:url>
-       </xsl:if>
-    </xsl:template>
+      </xsl:if>
+   </xsl:template>
+
+
 
 </xsl:stylesheet>


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- adjust the XSLT templates of id ( Identifier) and url in software for codemeta 
- the templates will work like following logic to avoid the prefix " oai:swmath.org: " and give us only the value 
-  of the id and url in the oai records 

- i could do the same update for datacite records if needed. 