### PR TITLE
Create a Datacite set to append only doi and arXiv records in oai

### DIFF
--- a/src/zbmath_rest2oai/getAsXml.py
+++ b/src/zbmath_rest2oai/getAsXml.py
@@ -69,6 +69,14 @@ def add_software(result):
     return zbmath_url.startswith("https://zbmath.org/software/")
 
 
+def datacite_records(result: dict) -> bool:
+    links = result.get("links", [])
+    for link in links:
+        if link.get("type") in ("doi", "arxiv") and link.get("identifier"):
+            return True
+    return False
+
+
 def extract_tags(result):
     tags = []
     for msc in result.get('msc', []):
@@ -87,6 +95,9 @@ def extract_tags(result):
 
     if add_software(result):
         tags.append('openaire')
+
+    if datacite_records(result):
+        tags.append('datacite')
 
     return tags
 

--- a/src/zbmath_rest2oai/get_sets.py
+++ b/src/zbmath_rest2oai/get_sets.py
@@ -10,7 +10,8 @@ def get_sets():
     mscs = {'JFM': 'JFM: Jahrbuch für Mathematik',
             'openaire': 'openaire Required set for OpenAIRE, cf.'
                         + 'https://guidelines.openaire.eu/en/latest/literature'
-                        + '/use_of_oai_pmh.html'}
+                        + '/use_of_oai_pmh.html',
+            'datacite': 'Datacite: for metadata supported with Doi and arXiv identifiers'}
     for result in results:
         code = result['code'][:2]
         mscs[code] = code + '-XX:' + result['short_title']

--- a/src/zbmath_rest2oai/get_sets.py
+++ b/src/zbmath_rest2oai/get_sets.py
@@ -7,11 +7,17 @@ def get_sets():
     headers = {'Accept': 'application/json'}
     r = requests.get(URL, headers=headers)
     results = r.json()['result']
-    mscs = {'JFM': 'JFM: Jahrbuch für Mathematik',
-            'openaire': 'openaire Required set for OpenAIRE, cf.'
-                        + 'https://guidelines.openaire.eu/en/latest/literature'
-                        + '/use_of_oai_pmh.html',
-            'datacite': 'Datacite: for metadata supported with Doi and arXiv identifiers'}
+    mscs = {
+        'JFM': 'JFM: Jahrbuch für Mathematik',
+        'openaire': ('openaire Required set for OpenAIRE, cf.'
+                     'https://guidelines.openaire.eu/en/latest/literature'
+                     '/use_of_oai_pmh.html'),
+        'datacite': (
+            'Datacite: for metadata supported with Doi and '
+            'arXiv identifiers'
+        )
+    }
+
     for result in results:
         code = result['code'][:2]
         mscs[code] = code + '-XX:' + result['short_title']

--- a/test/test_extract_tags.py
+++ b/test/test_extract_tags.py
@@ -12,7 +12,7 @@ class PlainXmlTest(unittest.TestCase):
             'https://api.zbmath.org/v1/document/_structured_search?page=0&results_per_page=10&zbmath%20id=2500495',
             headers=headers)
         real_tags = extract_tags(r.json()['result'][0])
-        assert real_tags == ['11', 'JFM']
+        assert real_tags == ['11', 'JFM', 'datacite']
 
     @staticmethod
     def test_software():

--- a/test/test_get_sets.py
+++ b/test/test_get_sets.py
@@ -7,5 +7,5 @@ class PlainXmlTest(unittest.TestCase):
     @staticmethod
     def test_getSets():
         real_sets = get_sets()
-        assert len(real_sets) == 65
+        assert len(real_sets) == 66
         assert real_sets['14'] == '14-XX:Algebraic geometry'


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- writing the setSpec , setName and description in the getSets.py for datacite 
- writing the function to filter the results for datacite set to accept only doi  and arxiv 
-  adding them to the datacite set after finishing the filtering. 

